### PR TITLE
Cleanup Typos and Use Int64

### DIFF
--- a/LQDownloadManager/LQDownloadManager.swift
+++ b/LQDownloadManager/LQDownloadManager.swift
@@ -140,7 +140,7 @@ extension LQDownloadManager {
     completeBlock: @escaping (LQDownloadState) -> Void
     ) {
     
-    if isComplate(urlString) {
+    if isComplete(urlString) {
       completeBlock(.complete)
       debugPrint("(￣.￣)该资源已下载完成")
       return
@@ -186,7 +186,7 @@ extension LQDownloadManager {
   }
   
   //判断该资源是否下载完成
-  public func isComplate(_ url: String) -> Bool {
+  public func isComplete(_ url: String) -> Bool {
     guard let size = fileTotalSize(url) else { return false }
     if size == fileDownloadSize(url) {
       return true

--- a/LQDownloadManager/LQDownloadManager.swift
+++ b/LQDownloadManager/LQDownloadManager.swift
@@ -25,7 +25,7 @@ open class LQDownloadManager: NSObject {
     var downloadTask: URLSessionDownloadTask
     var progressBlock: (CGFloat) -> Void
     var completeBlock: (LQDownloadState) -> Void
-    var fileExpectedSize: Int?
+    var fileExpectedSize: Int64?
   }
   
   public static let shared = LQDownloadManager()
@@ -107,13 +107,13 @@ extension LQDownloadManager: URLSessionDownloadDelegate, URLSessionDataDelegate 
     //存储总长度
     if downloadModel.fileExpectedSize == nil {
       
-      downloadModel.fileExpectedSize = Int(totalBytesExpectedToWrite)
+      downloadModel.fileExpectedSize = Int64(totalBytesExpectedToWrite)
       
       var dict = NSMutableDictionary(contentsOf: URL(fileURLWithPath: totalLengthFullPath()))
       if dict == nil {
         dict = NSMutableDictionary()
       }
-      dict?[fileName(urlString)] = Int(totalBytesExpectedToWrite)
+      dict?[fileName(urlString)] = Int64(totalBytesExpectedToWrite)
       dict?.write(toFile: totalLengthFullPath(), atomically: true)
     }
     
@@ -242,10 +242,10 @@ extension LQDownloadManager {
   }
   
   //获取对应资源的大小: 大小存储在totalLength.plist, key为url
-  public func fileTotalSize(_ url: String) -> Int? {
+  public func fileTotalSize(_ url: String) -> Int64? {
     if let data = try? Data(contentsOf: URL(fileURLWithPath: totalLengthFullPath())){
       if let result = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] {
-        return result?[fileName(url)] as? Int
+        return result?[fileName(url)] as? Int64
       }
     }
     return nil
@@ -263,12 +263,12 @@ extension LQDownloadManager {
   }
   
   //文件已下载大小
-  func fileDownloadSize(_ url: String) -> Int {
-    var filesize: Int?
+  func fileDownloadSize(_ url: String) -> Int64 {
+    var filesize: Int64?
     
     do {
       let attr = try FileManager.default.attributesOfItem(atPath: fileFullPath(url))
-      filesize = attr[FileAttributeKey.size] as? Int
+      filesize = attr[FileAttributeKey.size] as? Int64
     } catch {
       return 0
     }


### PR DESCRIPTION
@ALVIN-YANG Hi. I cleaned up a typo and also changed Int to Int64. Using Int would lead to truncation of Int64 when the file is too big. Kindly review.