### PR TITLE
Make State Names Consistent

### DIFF
--- a/Example/LQDownload/ViewController.swift
+++ b/Example/LQDownload/ViewController.swift
@@ -81,13 +81,13 @@ extension ViewController {
       self.progressView.progress = Float(progress)
     }) { status in
       switch status {
-      case .start:
+      case .started:
         print("开始下载")
         self.downloadButton.setTitle("暂停下载", for: .normal)
-      case .suspend:
+      case .suspended:
         print("下载暂停")
         self.downloadButton.setTitle("开始下载", for: .normal)
-      case .complete:
+      case .completed:
         print("下载完成")
         self.downloadButton.setTitle("下载完成", for: .normal)
       case .failed:

--- a/LQDownloadManager/LQDownloadManager.swift
+++ b/LQDownloadManager/LQDownloadManager.swift
@@ -14,9 +14,9 @@ open class LQDownloadManager: NSObject {
   
   // 下载状态
   public enum LQDownloadState {
-    case start
-    case suspend
-    case complete
+    case started
+    case suspended
+    case completed
     case failed
   }
   
@@ -75,7 +75,7 @@ extension LQDownloadManager: URLSessionDownloadDelegate, URLSessionDataDelegate 
     }
     
     OperationQueue.main.addOperation {
-      downloadModel.completeBlock(.complete)
+      downloadModel.completeBlock(.completed)
     }
   }
   
@@ -141,7 +141,7 @@ extension LQDownloadManager {
     ) {
     
     if isComplete(urlString) {
-      completeBlock(.complete)
+      completeBlock(.completed)
       debugPrint("(￣.￣)该资源已下载完成")
       return
     }
@@ -161,7 +161,7 @@ extension LQDownloadManager {
     let downloadTask = session.downloadTask(with: url)
     let downloadModel = LQDownloadModel(url: urlString, downloadTask: downloadTask, progressBlock: progress, completeBlock: completeBlock, fileExpectedSize: nil)
     
-    downloadModel.completeBlock(.start)
+    downloadModel.completeBlock(.started)
     onGoingDownloads[urlString] = downloadModel
     downloadTask.resume()
   }
@@ -285,11 +285,11 @@ extension LQDownloadManager {
     switch task.state {
     case .running:
       task.suspend()
-      onGoingDownloads[urlString]?.completeBlock(.suspend)
+      onGoingDownloads[urlString]?.completeBlock(.suspended)
     case .canceling,
          .suspended:
       task.resume()
-      onGoingDownloads[urlString]?.completeBlock(.start)
+      onGoingDownloads[urlString]?.completeBlock(.started)
     case .completed:
       break
     }

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ LQDownloadManager.shared.download("#download file url string#", progress: {
     status in
  
       switch status {
-      case .start:
+      case .started:
       
         // ...
-      case .suspend:
+      case .suspended:
       
        // ...
-      case .complete:
+      case .completed:
       
        // ...
       case .failed:


### PR DESCRIPTION
Use consistent Download State names, i.e. started instead of start etc.

@ALVIN-YANG Please review, test, merge and release these changes.